### PR TITLE
ADD CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+# This is a basic workflow to help you get started with Actions
+
+name: CI
+
+# Controls when the workflow will run
+on:
+  # Triggers the workflow on push or pull request events but only for the develop branch
+  push:
+    branches: [ develop ]
+  pull_request:
+    branches: [ develop ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+      - uses: actions/checkout@v2
+      
+      - name: Setup Node.js environment
+        uses: actions/setup-node@v2
+
+      - name: Set up MATLAB
+        uses: matlab-actions/setup-matlab@v1
+
+      - name: run shell commands
+        run: |
+          ls -R /home/runner/.matlab/
+          
+      - name: Run Matlab commands
+        uses: matlab-actions/run-command@v1
+        with:
+          command: convert;
+          
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/develop' }}
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./convert/public

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,8 +2,5 @@
     "files.associations": {"*.m": "matlab"},
     "[matlab]": {
         "files.encoding": "gb2312"
-    },
-    "yaml.schemas": {
-        "https://json.schemastore.org/github-workflow.json": "file:///e%3A/gitrepo/university-learning-code/.github/workflows/build.yml"
     }
 }


### PR DESCRIPTION
I want to ADD a CI for converting all MATLAB live scripts to html via github action.
I use [this api](https://ww2.mathworks.cn/matlabcentral/answers/282820-programmatically-run-and-export-live-script) to convert.
But it needs a display which github hosted runner doesn't offer [issue #14](https://github.com/matlab-actions/run-command/issues/14).
I may wait until the new api comes out.

the R2022a release is tested well with my local machine while I can't use it in action now.

3rd-party tools may help convert

- https://github.com/gllmflndn/m2html