### PR TITLE
try to use github action to publish mlx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,8 @@ jobs:
       - name: run shell commands
         run: |
           ls -R /home/runner/.matlab/
+          mkdir /home/runner/.matlab/R2022a/
+          touch /home/runner/.matlab/R2022a/thisMatlab.pem
           cd convert/
           yarn
           

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,10 @@ jobs:
           command: convert;
         env:
           DISPLAY: ":99.0"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: convert-errors
+          path: errors.mat
           
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,11 +39,15 @@ jobs:
           touch /home/runner/.matlab/R2022a/thisMatlab.pem
           cd convert/
           yarn
+          /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
+          echo ">>> Started xvfb"
           
       - name: Run Matlab commands
         uses: matlab-actions/run-command@v1
         with:
           command: convert;
+        env:
+          DISPLAY: ":99.0"
           
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3

--- a/convert/mlxs2html.m
+++ b/convert/mlxs2html.m
@@ -13,7 +13,7 @@ function mlxs2html(taskFile,dry_run_convert)
             else
                 if exist('export','file')
                     fprintf("%d: export %s-->%s",i,src,dst)
-                    export(src,dst);
+                    export(src,dst,CatchError=false,HideCode=false);
                 else
                     fprintf("%d: openAndConvert %s-->%s",i,src,dst)
                     matlab.internal.liveeditor.openAndConvert(src,dst);

--- a/convert/mlxs2html.m
+++ b/convert/mlxs2html.m
@@ -11,12 +11,16 @@ function mlxs2html(taskFile,dry_run_convert)
             if dry_run_convert
                 fprintf("dry-run")
             else
-                if exist('export','file')
-                    fprintf("%d: export %s-->%s",i,src,dst)
-                    export(src,dst,CatchError=false,HideCode=false);
-                else
-                    fprintf("%d: openAndConvert %s-->%s",i,src,dst)
-                    matlab.internal.liveeditor.openAndConvert(src,dst);
+                try
+                    if exist('export','file')
+                        fprintf("%d: export %s-->%s",i,src,dst)
+                        export(src,dst,CatchError=false,HideCode=false);
+                    else
+                        fprintf("%d: openAndConvert %s-->%s",i,src,dst)
+                        matlab.internal.liveeditor.openAndConvert(src,dst);
+                    end
+                catch err 
+                    disp(err)
                 end
             end
             fprintf("\n")

--- a/convert/mlxs2html.m
+++ b/convert/mlxs2html.m
@@ -20,7 +20,9 @@ function mlxs2html(taskFile,dry_run_convert)
                         matlab.internal.liveeditor.openAndConvert(src,dst);
                     end
                 catch err 
-                    disp(err)
+                    disp(err.identifier);
+                    disp(err.message);
+                    disp(err.stack);
                 end
             end
             fprintf("\n")

--- a/convert/mlxs2html.m
+++ b/convert/mlxs2html.m
@@ -20,9 +20,12 @@ function mlxs2html(taskFile,dry_run_convert)
                         matlab.internal.liveeditor.openAndConvert(src,dst);
                     end
                 catch err 
-                    disp(err.identifier);
-                    disp(err.message);
-                    disp(err.stack);
+                    save('errors.mat','err');
+                    for i=1:length(err.stack)
+                        e=err.stack(i);
+                        fprintf("%s %d\n",e.file,e.line)
+                    end
+                    break
                 end
             end
             fprintf("\n")


### PR DESCRIPTION
now Matlab provides a command to convert "mlx" file to "HTML" named [`convert`](https://ww2.mathworks.cn/help/matlab/ref/export.html).
Before this, I use command [`matlab.internal.richeditor.openAndConvert`](https://ww2.mathworks.cn/matlabcentral/answers/282820-programmatically-run-and-export-live-script) in #1 

However, they cannot work in Github hosted runner

- [Use MATLAB with GitHub Actions](https://github.com/matlab-actions/overview/blob/main/README.md)